### PR TITLE
Serve uploaded blob contents

### DIFF
--- a/filebox/models/uploads.py
+++ b/filebox/models/uploads.py
@@ -15,6 +15,10 @@ class FileBlob(db.Document):
 
     meta = { 'strict': True, 'collection': 'blobs' }
 
+    @property
+    def database(self):
+        return db.get_db()
+
 
 class FileUpload(db.Document):
     """ File upload entity """

--- a/filebox/urls.py
+++ b/filebox/urls.py
@@ -1,5 +1,6 @@
 
 from filebox.views import app
+from filebox.views.blobs import blobs, BlobsView
 from filebox.views.uploads import uploads, Uploads, UploadItem
 
 
@@ -12,8 +13,10 @@ class Routes:
     def rules(self):
         uploads.add_url_rule('/uploads', view_func=Uploads.as_view('items'))
         uploads.add_url_rule('/upload/<id>', view_func=UploadItem.as_view('item'))
+        blobs.add_url_rule('/upload/<id>/blobs', view_func=BlobsView.as_view('show'))
         return self
 
     @staticmethod
     def register():
         app.register_blueprint(uploads)
+        app.register_blueprint(blobs)

--- a/filebox/utils.py
+++ b/filebox/utils.py
@@ -1,7 +1,14 @@
 
+import json
+
 from flask import make_response
 from flask import jsonify as JSON
 
 
 def jsonify(content, status=200):
+    try:
+        content = json.loads(content)
+    except Exception:
+        pass
+
     return make_response(JSON(content), status)

--- a/filebox/views/blobs.py
+++ b/filebox/views/blobs.py
@@ -1,0 +1,30 @@
+
+from gridfs import GridFS
+from mongoengine import get_db
+from mongoengine.errors import FieldDoesNotExist
+from flask import send_file
+from flask import Blueprint
+from flask.views import MethodView
+
+from filebox.models import FileBlob, FileUpload
+from filebox.utils import jsonify
+
+
+blobs = Blueprint('blobs', __name__)
+
+
+class BlobsView(MethodView):
+    db = get_db()
+
+    def get(self, id):
+        fs = GridFS(self.db)
+        try:
+            upload = FileUpload.objects.get(id=id)
+            blob = FileBlob.objects.get(id=upload.blob.id)
+
+            file = fs.get(blob.uri.grid_id)
+            return send_file(file, as_attachment=False, mimetype=blob.type.value)
+        except FieldDoesNotExist:
+            return jsonify({'error': 'Unable to fetch file(%s)' % str(id)}, 400)
+        except (FileBlob.DoesNotExist, FileUpload.DoesNotExist):
+            return jsonify({'error': 'File(%s) not found' % str(id)}, 404)

--- a/filebox/views/blobs.py
+++ b/filebox/views/blobs.py
@@ -1,6 +1,5 @@
 
 from gridfs import GridFS
-from mongoengine import get_db
 from mongoengine.errors import FieldDoesNotExist
 from flask import send_file
 from flask import Blueprint
@@ -14,14 +13,12 @@ blobs = Blueprint('blobs', __name__)
 
 
 class BlobsView(MethodView):
-    db = get_db()
-
     def get(self, id):
-        fs = GridFS(self.db)
         try:
             upload = FileUpload.objects.get(id=id)
             blob = FileBlob.objects.get(id=upload.blob.id)
 
+            fs = GridFS(blob.database)
             file = fs.get(blob.uri.grid_id)
             return send_file(file, as_attachment=False, mimetype=blob.type.value)
         except FieldDoesNotExist:

--- a/filebox/views/uploads.py
+++ b/filebox/views/uploads.py
@@ -33,17 +33,17 @@ class Uploads(MethodView):
             supported = [choice.value for choice in FileBlob.type.choices]
             if file.mimetype in supported:
                 mime = Magic(mime=True)
-                content = copy(file.stream)
-                actual = mime.from_buffer(content.read())
+                contents = copy(file.stream.read())
+                mimetype = mime.from_buffer(contents)
 
-                if actual in supported:
+                if mimetype in supported:
                     kwargs = {
-                        'type': actual,
-                        'size': content.tell(),
+                        'type': mimetype,
+                        'size': len(contents),
                         'name': secure_filename(file.filename),
                     }
                     blob = FileBlob(**kwargs)
-                    blob.uri.put(content, content_type=actual)
+                    blob.uri.put(contents, content_type=mimetype)
                     blob.save()
 
                     return jsonify(FileUpload(blob=blob).save().to_json())

--- a/run.py
+++ b/run.py
@@ -6,10 +6,7 @@ import mongomock as MockDB
 from mongomock.gridfs import enable_gridfs_integration
 
 from filebox.views import app
-from filebox.urls import Routes
 
-
-Routes.setup()
 
 enable_gridfs_integration()
 db.connect(
@@ -17,6 +14,9 @@ db.connect(
     host=app.config.get('MONGODB_HOST'),
     mongo_client_class=MockDB.MongoClient
 )
+
+from filebox.urls import Routes
+Routes.setup()
 
 app.run(
     debug=True,

--- a/run.py
+++ b/run.py
@@ -6,6 +6,7 @@ import mongomock as MockDB
 from mongomock.gridfs import enable_gridfs_integration
 
 from filebox.views import app
+from filebox.urls import Routes
 
 
 enable_gridfs_integration()
@@ -15,7 +16,6 @@ db.connect(
     mongo_client_class=MockDB.MongoClient
 )
 
-from filebox.urls import Routes
 Routes.setup()
 
 app.run(

--- a/tests/test_models_uploads.py
+++ b/tests/test_models_uploads.py
@@ -111,9 +111,10 @@ class TestFileUpload(unittest.TestCase):
         blob = self.blob('test.png', save=True)
         upload = FileUpload(blob=blob.id).save()
         before = deepcopy(upload)
-        upload.save()
 
-        self.assertNotEqual(before.state, upload.state)
+        upload.hidden = True
+        upload.save()
+        self.assertNotEqual(before.hidden, upload.hidden)
 
     def test_delete_file_upload(self):
         blob = self.blob('test.jpg', save=True)

--- a/tests/test_views_uploads.py
+++ b/tests/test_views_uploads.py
@@ -76,30 +76,30 @@ class TestUploads(unittest.TestCase):
         r = self.app.get(self.url + '/uploads')
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(len(json.loads(r.json)), 3)
+        self.assertEqual(len(r.json), 3)
 
     def test_hidden_uploads(self):
         Fixtures.add(hidden=True)
 
         r = self.app.get(self.url + '/uploads')
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(len(json.loads(r.json)), 3)
+        self.assertEqual(len(r.json), 3)
 
         r = self.app.get(self.url + '/uploads?all=false')
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(len(json.loads(r.json)), 3)
+        self.assertEqual(len(r.json), 3)
 
         r = self.app.get(self.url + '/uploads?all=true')
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(len(json.loads(r.json)), 4)
+        self.assertEqual(len(r.json), 4)
 
         r = self.app.get(self.url + '/uploads?hidden=false')
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(len(json.loads(r.json)), 3)
+        self.assertEqual(len(r.json), 3)
 
         r = self.app.get(self.url + '/uploads?hidden=true')
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(len(json.loads(r.json)), 4)
+        self.assertEqual(len(r.json), 4)
 
     def test_create_upload(self):
         with open(fixtures.get('test.mp4'), 'rb') as fd:
@@ -124,17 +124,16 @@ class TestUploads(unittest.TestCase):
             r = self.app.post(self.url + '/uploads',
                               data={'file': (BytesIO(fd.read()), 'test.png')},
                               content_type='multipart/form-data')
-            item = json.loads(r.json)
 
             self.assertEqual(r.status_code, 200)
-            self.assertFalse(item.get('hidden'))
-            self.assertTrue('blob' in item.keys())
+            self.assertFalse(r.json.get('hidden'))
+            self.assertTrue('blob' in r.json.keys())
 
             self.assertGreater(FileBlob.objects.count(), 3)
-            self.assertIsNotNone(FileBlob.objects.get(id=item.get('blob').get('$oid')))
+            self.assertIsNotNone(FileBlob.objects.get(id=r.json.get('blob').get('$oid')))
 
             self.assertGreater(FileUpload.objects.count(), 3)
-            self.assertIsNotNone(FileUpload.objects.get(id=item.get('_id').get('$oid')))
+            self.assertIsNotNone(FileUpload.objects.get(id=r.json.get('_id').get('$oid')))
 
     def test_bulk_delete_uploads(self):
         """TODO: Add tests"""
@@ -171,17 +170,15 @@ class TestUploadItem(unittest.TestCase):
         self.assertEqual(r.status_code, 404)
 
         r = self.app.get(self.url + '/upload/%s' % str(ex.id))
-        item = json.loads(r.json)
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(item.get('_id').get('$oid'), str(ex.id))
+        self.assertEqual(r.json.get('_id').get('$oid'), str(ex.id))
 
         Fixtures.add(hidden=True)
         ex = FileUpload.objects.get(hidden=True)
         r = self.app.get(self.url + '/upload/%s' % str(ex.id))
-        item = json.loads(r.json)
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(item.get('_id').get('$oid'), str(ex.id))
-        self.assertTrue(item.get('hidden'))
+        self.assertEqual(r.json.get('_id').get('$oid'), str(ex.id))
+        self.assertTrue(r.json.get('hidden'))
 
     def test_put_upload_item(self):
         ex = FileUpload.objects.first()
@@ -192,16 +189,14 @@ class TestUploadItem(unittest.TestCase):
         self.assertEqual(r.status_code, 404)
 
         r = self.app.put(self.url + '/upload/%s' % str(ex.id), json={'hidden': True})
-        item = json.loads(r.json)
         self.assertEqual(r.status_code, 200)
-        self.assertTrue(item.get('hidden'))
-        self.assertEqual(item.get('_id').get('$oid'), str(ex.id))
+        self.assertTrue(r.json.get('hidden'))
+        self.assertEqual(r.json.get('_id').get('$oid'), str(ex.id))
 
         r = self.app.put(self.url + '/upload/%s' % str(ex.id), json={'hidden': False})
-        item = json.loads(r.json)
         self.assertEqual(r.status_code, 200)
-        self.assertFalse(item.get('hidden'))
-        self.assertEqual(item.get('_id').get('$oid'), str(ex.id))
+        self.assertFalse(r.json.get('hidden'))
+        self.assertEqual(r.json.get('_id').get('$oid'), str(ex.id))
 
     def test_delete_upload_item(self):
         r = self.app.delete(self.url + '/upload/foobar')


### PR DESCRIPTION
- Expose an endpoint to view a user uploaded `FileBlob`.
- Blobs are stored in Mongo's GridFS storage.